### PR TITLE
Stable output hashes

### DIFF
--- a/pkg/provider/data_lambda.go
+++ b/pkg/provider/data_lambda.go
@@ -7,8 +7,8 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"sort"
 	"path/filepath"
-	"time"
 	"path"
 
 	"github.com/chanzuckerberg/terraform-provider-bless/pkg/util"
@@ -95,19 +95,15 @@ func newResourceLambda() *resourceLambda {
 	return &resourceLambda{}
 }
 
-func (l *resourceLambda) writeFileToZip(f io.Reader, fileInfo os.FileInfo, writer *zip.Writer, path string,
+func (l *resourceLambda) writeFileToZip(f io.Reader, writer *zip.Writer, path string,
 ) error {
 	relativeName, err := filepath.Rel("", path)
 	if err != nil {
 		return errors.Wrapf(err, "Could not create relative path %s for zip", path)
 	}
-	fh, err := zip.FileInfoHeader(fileInfo)
-	if err != nil {
-		return errors.Wrapf(err, "Could not create zip file header for %s", relativeName)
-	}
+	fh := &zip.FileHeader{}
 	fh.Name = filepath.ToSlash(relativeName)
 	fh.Method = zip.Deflate
-	fh.SetModTime(time.Time{})
 	w, err := writer.CreateHeader(fh)
 	if err != nil {
 		return errors.Wrapf(err, "Could not create zip writer for %s", relativeName)
@@ -117,23 +113,19 @@ func (l *resourceLambda) writeFileToZip(f io.Reader, fileInfo os.FileInfo, write
 }
 
 // getBlessConfig reads and templetizes a bless config
-func (l *resourceLambda) getBlessConfig(d *schema.ResourceData) (io.Reader, os.FileInfo, error) {
+func (l *resourceLambda) getBlessConfig(d *schema.ResourceData) (io.Reader, error) {
 	templateBox := packr.NewBox("../../bless_lambda")
 	tpl, err := templateBox.Open("bless_deploy.cfg.tpl")
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "Could not open pckr box for bless_deploy.cfg.tpl")
+		return nil, errors.Wrap(err, "Could not open pckr box for bless_deploy.cfg.tpl")
 	}
 	tplBytes, err := ioutil.ReadAll(tpl)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "Could not read bless_deploy.cfg.tpl")
-	}
-	fileInfo, err := tpl.Stat()
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "Could not stat bless_deploy.cfg.tpl")
+		return nil, errors.Wrap(err, "Could not read bless_deploy.cfg.tpl")
 	}
 	t, err := template.New("config").Parse(string(tplBytes))
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "Could not load template")
+		return nil, errors.Wrap(err, "Could not load template")
 	}
 	blessConfig := blessConfig{
 		EncryptedPassword:   d.Get(schemaEncryptedPassword).(string),
@@ -143,7 +135,7 @@ func (l *resourceLambda) getBlessConfig(d *schema.ResourceData) (io.Reader, os.F
 	}
 	buff := bytes.NewBuffer(nil)
 	err = t.Execute(buff, blessConfig)
-	return buff, fileInfo, errors.Wrap(err, "Could not templetize config")
+	return buff, errors.Wrap(err, "Could not templetize config")
 }
 
 // archive generates the zip archive
@@ -168,20 +160,39 @@ func (l *resourceLambda) archive(d *schema.ResourceData, meta interface{}) error
 
 	// Add all the python lambda files to the zip
 	zipBox := packr.NewBox("../../bless_lambda/bless_ca")
+	// HACK: zipBox.Walk does not guarantee a stable iteration order
+	files:= []string{}
 	err = zipBox.Walk(func(path string, f packr.File) error {
 		fileInfo, err := f.FileInfo()
 		if err != nil {
 			return errors.Wrapf(err, "Could not get file info for %s", path)
 		}
-		return l.writeFileToZip(f, fileInfo, writer, path)
+		if fileInfo.IsDir() {
+			return nil
+		}
+		files = append(files, path)
+		return nil
 	})
 
-	blessConfig, blessConfigFileInfo, err := l.getBlessConfig(d)
+	// Sort so stable adding of files to zip
+	sort.Strings(files)
+	for _, path := range files {
+		f, err := zipBox.Open(path)
+		if err != nil {
+			return errors.Wrapf(err, "Could not open file %s", path)
+		}
+		err = l.writeFileToZip(f, writer, path)
+		if err != nil {
+			return err
+		}
+	}
+
+	blessConfig, err := l.getBlessConfig(d)
 	if err != nil {
 		return err
 	}
 	// Write the config
-	return l.writeFileToZip(blessConfig, blessConfigFileInfo, writer, "bless_deploy.cfg")
+	return l.writeFileToZip(blessConfig, writer, "bless_deploy.cfg")
 }
 
 // Create bundles the lambda code and configuration into a zip that can be uploaded to AWS lambda

--- a/pkg/provider/data_lambda_test.go
+++ b/pkg/provider/data_lambda_test.go
@@ -3,7 +3,6 @@ package provider_test
 import (
 	"testing"
 
-	"github.com/chanzuckerberg/terraform-provider-bless/pkg/provider"
 	r "github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/stretchr/testify/assert"
@@ -31,13 +30,30 @@ func TestLambdaCreate(t *testing.T) {
 					output_path = "/tmp/test.zip"
 				}
 
-				output "output_base64sha256" {
+				data "bless_lambda" "zip2" {
+					encrypted_ca = "aaaa"
+					encrypted_password = "bbbb"
+					service_name = "test"
+					kmsauth_key_id = "keyID"
+					output_path = "/tmp/test2.zip"
+				}
+
+
+				output "output" {
 					value = "${data.bless_lambda.zip.output_base64sha256}"
 				}
+				output "output_2" {
+					value = "${data.bless_lambda.zip2.output_base64sha256}"
+				}
+
 				`,
 				Check: func(s *terraform.State) error {
-					base64sha256 := s.RootModule().Outputs[provider.SchemaOutputBase64Sha256].Value
-					a.NotEmpty(base64sha256)
+					output1:= s.RootModule().Outputs["output"].Value
+					output2:= s.RootModule().Outputs["output_2"].Value
+					a.NotEmpty(output1)
+					a.NotEmpty(output2)
+					// Check hashes are equal
+					a.Equal(output1, output2)
 					return nil
 				},
 				Destroy: true,

--- a/pkg/provider/data_lambda_test.go
+++ b/pkg/provider/data_lambda_test.go
@@ -45,7 +45,6 @@ func TestLambdaCreate(t *testing.T) {
 				output "output_2" {
 					value = "${data.bless_lambda.zip2.output_base64sha256}"
 				}
-
 				`,
 				Check: func(s *terraform.State) error {
 					output1:= s.RootModule().Outputs["output"].Value


### PR DESCRIPTION
packerbox.Walk did not walk in a stable order which caused zip archive signatures to vary. setting a fixed iteration order here