### PR TITLE
Version provider binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,5 @@
 builds:
-  - binary: terraform-provider-bless
+  - binary: "terraform-provider-bless-{{ .Tag }}"
     env:
       - CGO_ENABLED=0
     goos:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,5 @@
 builds:
-  - binary: "terraform-provider-bless-{{ .Tag }}"
+  - binary: "terraform-provider-bless_{{ .Tag }}"
     env:
       - CGO_ENABLED=0
     goos:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-build:
+build: packr
 	@CGO_ENABLED=0 GOOS=linux go build -o terraform-provider-bless
 
 test:

--- a/bless_lambda/bless_deploy.cfg.tpl
+++ b/bless_lambda/bless_deploy.cfg.tpl
@@ -3,7 +3,7 @@ certificate_validity_after_seconds = 3600
 certificate_validity_before_seconds = 3600
 entropy_minimum_bits = 2048
 random_seed_bytes = 256
-logging_level = INFO
+logging_level = DEBUG
 username_validation = email
 
 [Bless CA]


### PR DESCRIPTION
to leverage terraform's provider versioning we have to publish the binary as `terraform-provider-NAME_vX.Y.Z`