### PR TITLE
[feature] role auth

### DIFF
--- a/.reviewdog.yml
+++ b/.reviewdog.yml
@@ -1,6 +1,6 @@
 runner:
   golangci:
-    cmd: ./bin/golangci-lint run --out-format=line-number
+    cmd: ./bin/golangci-lint run --out-format=line-number -v --timeout 5m
     errorformat:
       - '%E%f:%l:%c: %m'
       - '%E%f:%l: %m'

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -27,8 +29,15 @@ func NewClient(d *schema.ResourceData) (*Client, error) {
 			Profile:           d.Get("profile").(string),
 		},
 	))
+
+	var creds *credentials.Credentials
+
+	if r, ok := d.Get("role_arn").(string); ok {
+		creds = stscreds.NewCredentials(sess, r)
+	}
+
 	client := &Client{
-		KMS: NewKMS(sess),
+		KMS: NewKMS(sess, creds),
 	}
 
 	return client, nil

--- a/pkg/aws/kms.go
+++ b/pkg/aws/kms.go
@@ -3,6 +3,8 @@ package aws
 import (
 	"encoding/base64"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/kms/kmsiface"
@@ -15,8 +17,8 @@ type KMS struct {
 }
 
 // NewKMS returns a KMS client
-func NewKMS(s *session.Session) KMS {
-	return KMS{kms.New(s)}
+func NewKMS(s *session.Session, creds *credentials.Credentials) KMS {
+	return KMS{kms.New(s, &aws.Config{Credentials: creds})}
 }
 
 // EncryptBytes encrypts the plaintext using the keyID key, result is base64 encoded

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -19,9 +19,14 @@ func Provider() *schema.Provider {
 				InputDefault: "us-east-1",
 			},
 			"profile": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "",
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"role_arn"},
+			},
+			"role_arn": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"profile"},
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{


### PR DESCRIPTION
Allow the provider to assume a specified role instead of using a profile
from the configuration.

Tested manually, both scenarios.

This might address #29.