### PR TITLE
fix: replace reviewdog secret with auto-generated github token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,5 @@ jobs:
         run: make setup
       - name: make ${{ matrix.target }}
         env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.REVIEWDOG_GITHUB_API_TOKEN }}
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make ${{ matrix.target }}


### PR DESCRIPTION
Github creates a token specific to every workflow run that grants access to the running repo. https://docs.github.com/en/actions/security-guides/automatic-token-authentication

This is a more secure way to access to the repo rather than the current approach of handling the access secret ourselves.